### PR TITLE
Wrapping integer literal in parentheses

### DIFF
--- a/content/en-CA/docs/2016/setting-properties-on-a-primitive-now-throws-in-strict-mode.md
+++ b/content/en-CA/docs/2016/setting-properties-on-a-primitive-now-throws-in-strict-mode.md
@@ -19,7 +19,7 @@ Previously, setting properties on a [primitive value](https://developer.mozilla.
 ```js
 (function() {
   "use strict";
-  10.sub = 5; // TypeError
+  (10).sub = 5; // TypeError
 })();
 ```
 ```js


### PR DESCRIPTION
Dot after integer literal is parsed as decimal point instead of property accessor. Wrapping the integer in parentheses prevents `SyntaxError: identifier starts immediately after numeric literal`.
